### PR TITLE
- updated unittest to properly detect poller.unregister's (adapted) call

### DIFF
--- a/pants/test/test_engine.py
+++ b/pants/test/test_engine.py
@@ -445,7 +445,7 @@ class TestEpoll(unittest.TestCase):
 
     def test_epoll_remove(self):
         self.poller.remove(self.fileno, self.events)
-        self.epoll.unregister.assert_called_once_with(self.fileno, self.events)
+        self.epoll.unregister.assert_called_once_with(self.fileno)
 
     def test_epoll_poll(self):
         timeout = 10


### PR DESCRIPTION
_EPoll.remove correctly adapts to select.unregister's call by discarding the events argument. As such, I modified the unit test, rather than pants' code.
