### PR TITLE
Unified API for pants.http.utils.HTTPHeaders

### DIFF
--- a/bin/pants_dig.py
+++ b/bin/pants_dig.py
@@ -24,8 +24,8 @@
 import optparse
 import sys
 
-from pants.util.dns import *
 from pants.compat import items
+from pants.util.dns import *
 
 ###############################################################################
 # Main

--- a/bin/pants_dig.py
+++ b/bin/pants_dig.py
@@ -25,6 +25,7 @@ import optparse
 import sys
 
 from pants.util.dns import *
+from pants.compat import items
 
 ###############################################################################
 # Main
@@ -58,12 +59,12 @@ if __name__ == '__main__':
 
         print ''
         print 'Detected IPv4 Hosts'
-        for k,v in hosts[A].iteritems():
+        for k, v in items(hosts[A]):
             print ' %-40s A     %s' % (k, v)
 
         print ''
         print 'Detected IPv6 Hosts'
-        for k,v in hosts[AAAA].iteritems():
+        for k, v in items(hosts[AAAA]):
             print ' %-40s AAAA  %s' % (k, v)
 
     if sys.platform == 'win32':
@@ -78,7 +79,7 @@ if __name__ == '__main__':
             qt = args.pop(0)
         else:
             qt = 'A'
-        
+
         qtype = []
         for t in qt.split(','):
             t = t.upper()
@@ -95,7 +96,7 @@ if __name__ == '__main__':
 
         # Build a Message
         m = DNSMessage()
-        
+
         for t in qtype:
             m.questions.append((host, t, IN))
 

--- a/examples/tutorial3.py
+++ b/examples/tutorial3.py
@@ -1,4 +1,5 @@
 from pants import Engine, Server, Stream
+from pants.compat import values
 
 class EchoLineToAll(Stream):
     def on_connect(self):
@@ -15,7 +16,7 @@ class EchoLineToAllServer(Server):
     ConnectionClass = EchoLineToAll
 
     def write_to_all(self, data):
-        for channel in self.channels.itervalues():
+        for channel in values(self.channels):
             if channel.connected:
                 channel.write(data)
 

--- a/pants/compat.py
+++ b/pants/compat.py
@@ -3,13 +3,13 @@
 '''
 
 def items(mapping):
-    ''' returns the dictionary's item view '''
-    return getattr(dictionary, 'viewitems', dictionary.items)()
+    ''' returns the mapping's item view '''
+    return getattr(mapping, 'viewitems', mapping.items)()
 
 def keys(mapping):
-    ''' returns the dictionary's key view '''
-    return getattr(dictionary, 'viewkeys', dictionary.keys)()
+    ''' returns the mapping's key view '''
+    return getattr(mapping, 'viewkeys', mapping.keys)()
 
 def values(mapping):
-    ''' returns the dictionary's value view '''
-    return getattr(dictionary, 'viewvalues', dictionary.values)()
+    ''' returns the mapping's value view '''
+    return getattr(mapping, 'viewvalues', mapping.values)()

--- a/pants/compat.py
+++ b/pants/compat.py
@@ -1,0 +1,15 @@
+''' Compatibility module that helps to resolve some inconsistencies between
+    python 2 and 3
+'''
+
+def items(mapping):
+    ''' returns the dictionary's item view '''
+    return getattr(dictionary, 'viewitems', dictionary.items)()
+
+def keys(mapping):
+    ''' returns the dictionary's key view '''
+    return getattr(dictionary, 'viewkeys', dictionary.keys)()
+
+def values(mapping):
+    ''' returns the dictionary's value view '''
+    return getattr(dictionary, 'viewvalues', dictionary.values)()

--- a/pants/engine.py
+++ b/pants/engine.py
@@ -314,7 +314,7 @@ class Engine(object):
             else:
                 raise
 
-        for fileno, events in items(event):
+        for fileno, events in items(events):
             channel = self._channels[fileno]
             try:
                 channel._handle_events(events)

--- a/pants/engine.py
+++ b/pants/engine.py
@@ -109,6 +109,8 @@ import select
 import sys
 import time
 
+from pants.compat import items
+
 
 ###############################################################################
 # Logging
@@ -312,7 +314,7 @@ class Engine(object):
             else:
                 raise
 
-        for fileno, events in events.iteritems():
+        for fileno, events in items(event):
             channel = self._channels[fileno]
             try:
                 channel._handle_events(events)
@@ -505,7 +507,7 @@ class Engine(object):
         =========  ============
         """
         if self._poller is not None:
-            for fileno, channel in self._channels.iteritems():
+            for fileno, channel in items(self._channels):
                 self._poller.remove(fileno, channel._events)
 
         if poller is not None:
@@ -517,7 +519,7 @@ class Engine(object):
         else:
             self._poller = _Select()
 
-        for fileno, channel in self._channels.iteritems():
+        for fileno, channel in items(self._channels):
             self._poller.add(fileno, channel._events)
 
 

--- a/pants/http/client.py
+++ b/pants/http/client.py
@@ -221,6 +221,7 @@ import zlib
 
 from datetime import datetime
 
+from pants.compat import items
 from pants.stream import Stream
 from pants.engine import Engine
 
@@ -781,7 +782,7 @@ class HTTPClient(object):
         self._stream.write("%s %s HTTP/1.1%s" % (request.method, path, CRLF))
 
         # Headers
-        for key, val in request.headers.iteritems():
+        for key, val in items(request.headers):
             self._stream.write("%s: %s%s" % (key, val, CRLF))
 
         # Cookies
@@ -1144,7 +1145,7 @@ class HTTPClient(object):
         del response._additional_headers
 
         # Extend the original headers.
-        for key, val in headers.iteritems():
+        for key, val in items(headers):
             if not key in response.headers:
                 response.headers[key] = val
             else:

--- a/pants/http/server.py
+++ b/pants/http/server.py
@@ -142,6 +142,7 @@ if sys.platform == "win32":
 else:
     from time import time
 
+from pants.compat import items
 from pants.stream import Stream
 from pants.server import Server
 
@@ -308,7 +309,7 @@ class HTTPConnection(Stream):
         except BadRequest as err:
             log.info('Bad request from %r: %s',
                 self.remote_address, err)
-            
+
             self.write('HTTP/1.1 %s%s' % (err.code, CRLF))
             if err.message:
                 self.write('Content-Type: text/html%s' % CRLF)
@@ -469,7 +470,7 @@ class HTTPRequest(object):
             thing = getattr(self, i)
             if thing:
                 if isinstance(thing, HTTPHeaders):
-                    thing = dict(thing.iteritems())
+                    thing = dict(items(thing))
                 out += u'    %-8s = {\n %s\n        }\n\n' % (
                     i, pprint.pformat(thing, 8)[1:-1])
             else:
@@ -596,7 +597,7 @@ class HTTPRequest(object):
         m['httponly'] = True
 
         if kwargs:
-            for k, v in kwargs.iteritems():
+            for k, v in items(kwargs):
                 if k.lower() == 'httponly' and not v:
                     del m['httponly']
                 else:

--- a/pants/http/utils.py
+++ b/pants/http/utils.py
@@ -28,7 +28,6 @@ import re
 import time
 
 from datetime import datetime
-from itertools import imap
 
 from pants import __version__ as pants_version
 from pants.compat import items
@@ -232,26 +231,16 @@ class HTTPHeaders(object):
                 return 0
         return len(self._data) == len(other)
 
-    def iteritems(self, _normalize_header=_normalize_header):
-        for k, v in items(self._data):
-            yield _normalize_header(k), v
-
-    def iterkeys(self):
-        return imap(_normalize_header, self._data)
-
-    __iter__ = iterkeys
-
-    def itervalues(self):
-        return values(self._data)
-
     def items(self, _normalize_header=_normalize_header):
-        return [(_normalize_header(k), v) for k,v in items(self._data)]
+        return iter((_normalize_header(k), v) for k, v in items(self._data))
 
     def keys(self, _normalize_header=_normalize_header):
-        return [_normalize_header(k) for k in self._data]
+        return iter(_normalize_header(k) for k in self._data)
+
+    __iter__ = keys
 
     def values(self):
-        return self._data.values()
+        return values(self._data)
 
     def update(self, iterable=None, **kwargs):
         if iterable:

--- a/pants/http/utils.py
+++ b/pants/http/utils.py
@@ -31,6 +31,7 @@ from datetime import datetime
 from itertools import imap
 
 from pants import __version__ as pants_version
+from pants.compat import items
 
 
 ###############################################################################
@@ -216,7 +217,7 @@ class HTTPHeaders(object):
             self.update(data)
 
     def __repr__(self):
-        return "%s(%r)" % (self.__class__.__name__, dict(self.iteritems()))
+        return "%s(%r)" % (self.__class__.__name__, self._data)
 
     def __len__(self):
         return len(self._data)
@@ -225,14 +226,14 @@ class HTTPHeaders(object):
         if isinstance(other, HTTPHeaders):
             return self._data == other._data
 
-        for k, v in self._data.iteritems():
+        for k, v in items(self._data):
             k = _normalize_header(k)
             if not (k in other) or not (other[k] == v):
                 return 0
         return len(self._data) == len(other)
 
     def iteritems(self, _normalize_header=_normalize_header):
-        for k, v in self._data.iteritems():
+        for k, v in items(self._data):
             yield _normalize_header(k), v
 
     def iterkeys(self):
@@ -241,10 +242,10 @@ class HTTPHeaders(object):
     __iter__ = iterkeys
 
     def itervalues(self):
-        return self._data.itervalues()
+        return values(self._data)
 
     def items(self, _normalize_header=_normalize_header):
-        return [(_normalize_header(k), v) for k,v in self._data.iteritems()]
+        return [(_normalize_header(k), v) for k,v in items(self._data)]
 
     def keys(self, _normalize_header=_normalize_header):
         return [_normalize_header(k) for k in self._data]
@@ -261,7 +262,7 @@ class HTTPHeaders(object):
                 for (k,v) in iterable:
                     self[k] = v
 
-        for k,v in kwargs.iteritems():
+        for k,v in items(kwargs):
             self[k] = v
 
     def __setitem__(self, key, value):
@@ -336,10 +337,10 @@ def encode_multipart(vars, files=None, boundary=None):
 
     out = []
 
-    for k, v in vars.iteritems():
+    for k, v in items(vars):
         out.append('--%s%sContent-Disposition: form-data; name="%s"%s%s%s' % (boundary, CRLF, k, DOUBLE_CRLF, v, CRLF))
     if files:
-        for k, v in files.iteritems():
+        for k, v in items(files):
             if isinstance(v, (list,tuple)):
                 fn, v = v
             else:

--- a/pants/test/core/test_echo_to_all.py
+++ b/pants/test/core/test_echo_to_all.py
@@ -21,11 +21,12 @@ import unittest
 
 import pants
 
+from pants.compat import values
 from pants.test._pants_util import *
 
 class EchoToAll(pants.Stream):
     def on_read(self, data):
-        for channel in self.server.channels.itervalues():
+        for channel in values(self.server.channels):
             channel.write(data)
 
 class TestEchoToAll(PantsTestCase):

--- a/pants/util/dns.py
+++ b/pants/util/dns.py
@@ -32,6 +32,7 @@ import struct
 import sys
 import time
 
+from pants.compat import items
 from pants.engine import Engine
 from pants.stream import Stream
 from pants.datagram import Datagram
@@ -116,7 +117,7 @@ RDATA_TYPES = {
 
 RDATA_TUPLES = {}
 
-for k,v in RDATA_TYPES.iteritems():
+for k,v in items(RDATA_TYPES):
     # Get the Name.
     nm = '%s_Record' % QTYPES[k-1]
 

--- a/pants/web/application.py
+++ b/pants/web/application.py
@@ -434,6 +434,7 @@ import urllib
 
 from datetime import datetime
 
+from pants.compat import items
 from pants.http.server import HTTPServer
 from pants.http.utils import HTTP, HTTPHeaders
 
@@ -1209,24 +1210,24 @@ class Application(Module):
         # Update the hooks system.
         if hooks:
             new_hooks = {}
-            for k, v in hooks.iteritems():
+            for k, v in items(hooks):
                 new_hooks[k] = v[:]
             hooks = new_hooks
         else:
             hooks = {}
 
-        for k,v in mod_hooks.iteritems():
+        for k,v in items(mod_hooks):
             if k in hooks:
                 hooks[k].extend(v)
             else:
                 hooks[k] = v[:]
 
         # Iterate through modules first, so our own rules are more important.
-        for rule, mod in modules.iteritems():
+        for rule, mod in items(modules):
             self._recalculate_routes(None, rule, mod, nameprefix, hooks)
 
         # Iterate through the unprocessed route table.
-        for rule, table in routes.iteritems():
+        for rule, table in items(routes):
             # If path is set, and this isn't an absolute rule, merge the rule
             # with the path.
             if path and (rule[0] == "/" or not "/" in rule):
@@ -1270,7 +1271,7 @@ class Application(Module):
 
             # Iterate through all the methods this rule provides.
             for method, (func, name, advanced, auto404, headers, content_type) \
-                    in table.iteritems():
+                    in items(table):
                 method = method.upper()
                 if method == 'GET' or rl[3] is None:
                     if nameprefix:
@@ -1515,7 +1516,7 @@ class Application(Module):
             else:
                 body, status = result
                 headers = HTTPHeaders()
-                
+
         else:
             body = result
             headers = HTTPHeaders()

--- a/pants/web/asynchronous.py
+++ b/pants/web/asynchronous.py
@@ -29,6 +29,7 @@ import weakref
 from functools import wraps
 from types import GeneratorType
 
+from pants.compat import items
 from pants.http.utils import HTTPHeaders
 
 from pants.web.application import Application, error, Response, RequestContext
@@ -495,7 +496,7 @@ def _event_stream_output(request, output):
     # Split up output, adding "data:" field names, and then prepend the
     # provided headers, if there are any.
     output = "\r\n".join("data: %s" % x for x in output.splitlines())
-    for key, value in headers.iteritems():
+    for key, value in items(headers):
         output = "%s: %s\r\n%s" % (key, _cast(request, value), output)
 
     # Write it out, with an extra blank line so that the client will read

--- a/pants/web/wsgi.py
+++ b/pants/web/wsgi.py
@@ -156,7 +156,7 @@ class WSGIConnector(object):
                 raise ValueError("status must be a string or int")
             if not isinstance(head, list):
                 if isinstance(head, dict):
-                    head = [(k,v) for k,v in head.iteritems()]
+                    head = list(items(head))
                 else:
                     try:
                         head = list(head)
@@ -210,7 +210,7 @@ class WSGIConnector(object):
         if 'Content-Length' in request.headers:
             environ['CONTENT_LENGTH'] = request.headers['Content-Length']
 
-        for k,v in request.headers._data.iteritems():
+        for k,v in items(request.headers._data):
             environ['HTTP_%s' % k.replace('-','_').upper()] = v
 
         # Run the WSGI Application.


### PR DESCRIPTION
This depends on (or supercedes) #52. 

Basically, I was trying to unify the API such that it remained python agnostic. As per the [zen of python](http://www.python.org/dev/peps/pep-0020/), there should be preferably one obvious way of doing something. As such, I got rid of `iteritems`, `itervalues` and `iterkeys`. If a user wants lists returned instead, they can explicitly cast as such. 

Clearly this is just an opinion, which is why I wanted to use a separate branch for these changes. I'm open to suggestions.
