### PR TITLE
Implemented a basestring fallback for python 3

### DIFF
--- a/pants/_channel.py
+++ b/pants/_channel.py
@@ -31,6 +31,7 @@ import socket
 import sys
 import time
 
+from pants.compat import basestring
 from pants.engine import Engine
 from pants.util.sendfile import sendfile
 
@@ -106,7 +107,7 @@ else:
 def sock_type(sock):
     """
     We can thank Linux for this abomination of a function.
-    
+
     As of Linux 2.6.27, bits 11-32 of the socket type are flags. This
     change was made with a complete lack of consideration for the fact
     that socket types are not flags, but are in fact "symbolic
@@ -114,7 +115,7 @@ def sock_type(sock):
     numbers. It is impossible to distinguish between some types (i.e.
     SOCK_STREAM and SOCK_RAW) using a simple bitwise AND, as one would
     expect from a flag value.
-    
+
     To get around this, we treat the first 9 bits as the "real" type.
     """
     return sock.type & 1023

--- a/pants/compat.py
+++ b/pants/compat.py
@@ -2,18 +2,6 @@
     python 2 and 3
 '''
 
-def items(mapping):
-    ''' returns the mapping's item view '''
-    return getattr(mapping, 'viewitems', mapping.items)()
-
-def keys(mapping):
-    ''' returns the mapping's key view '''
-    return getattr(mapping, 'viewkeys', mapping.keys)()
-
-def values(mapping):
-    ''' returns the mapping's value view '''
-    return getattr(mapping, 'viewvalues', mapping.values)()
-
 try:
     basestring = basestring
 except NameError:

--- a/pants/compat.py
+++ b/pants/compat.py
@@ -15,6 +15,6 @@ def values(mapping):
     return getattr(mapping, 'viewvalues', mapping.values)()
 
 try:
-    basestring
+    basestring = basestring
 except NameError:
     basestring = str

--- a/pants/compat.py
+++ b/pants/compat.py
@@ -1,0 +1,20 @@
+''' Compatibility module that helps to resolve some inconsistencies between
+    python 2 and 3
+'''
+
+def items(mapping):
+    ''' returns the mapping's item view '''
+    return getattr(mapping, 'viewitems', mapping.items)()
+
+def keys(mapping):
+    ''' returns the mapping's key view '''
+    return getattr(mapping, 'viewkeys', mapping.keys)()
+
+def values(mapping):
+    ''' returns the mapping's value view '''
+    return getattr(mapping, 'viewvalues', mapping.values)()
+
+try:
+    basestring
+except NameError:
+    basestring = str

--- a/pants/contrib/irc.py
+++ b/pants/contrib/irc.py
@@ -23,6 +23,7 @@
 import logging
 import re
 
+from pants.compat import basestring
 from pants.stream import Stream
 
 ###############################################################################

--- a/pants/contrib/telnet.py
+++ b/pants/contrib/telnet.py
@@ -23,6 +23,7 @@
 import re
 import struct
 
+from pants.compat import basestring
 from pants import Stream, Server
 
 try:

--- a/pants/datagram.py
+++ b/pants/datagram.py
@@ -27,6 +27,7 @@ import re
 import socket
 import struct
 
+from pants.compat import basestring
 from pants._channel import _Channel
 
 

--- a/pants/http/client.py
+++ b/pants/http/client.py
@@ -221,6 +221,7 @@ import zlib
 
 from datetime import datetime
 
+from pants.compat import basestring
 from pants.stream import Stream
 from pants.engine import Engine
 

--- a/pants/http/server.py
+++ b/pants/http/server.py
@@ -142,6 +142,7 @@ if sys.platform == "win32":
 else:
     from time import time
 
+from pants.compat import basestring
 from pants.stream import Stream
 from pants.server import Server
 
@@ -308,7 +309,7 @@ class HTTPConnection(Stream):
         except BadRequest as err:
             log.info('Bad request from %r: %s',
                 self.remote_address, err)
-            
+
             self.write('HTTP/1.1 %s%s' % (err.code, CRLF))
             if err.message:
                 self.write('Content-Type: text/html%s' % CRLF)

--- a/pants/http/websocket.py
+++ b/pants/http/websocket.py
@@ -332,6 +332,7 @@ if sys.platform == "win32":
 else:
     from time import time
 
+from pants.compat import basestring
 from pants.stream import StreamBufferOverflow
 from pants.http.utils import log
 

--- a/pants/stream.py
+++ b/pants/stream.py
@@ -103,7 +103,7 @@ code. Pants handles these errors by passing the resulting exception
 object to one of a number of error handler methods. They are:
 :meth:`~pants.stream.Stream.on_connect_error`,
 :meth:`~pants.stream.Stream.on_overflow_error` and
-:meth:`~pants.stream.Stream.on_error`. Additionally, 
+:meth:`~pants.stream.Stream.on_error`. Additionally,
 :meth:`~pants.stream.Stream.on_ssl_handshake_error` and
 :meth:`~pants.stream.Stream.on_ssl_error` exist to handle SSL-specific
 errors.
@@ -142,6 +142,7 @@ import socket
 import ssl
 import struct
 
+from pants.compat import basestring
 from pants._channel import _Channel, HAS_IPV6, sock_type
 from pants.engine import Engine
 

--- a/pants/web/application.py
+++ b/pants/web/application.py
@@ -434,6 +434,7 @@ import urllib
 
 from datetime import datetime
 
+from pants.compat import basestring
 from pants.http.server import HTTPServer
 from pants.http.utils import HTTP, HTTPHeaders
 
@@ -1515,7 +1516,7 @@ class Application(Module):
             else:
                 body, status = result
                 headers = HTTPHeaders()
-                
+
         else:
             body = result
             headers = HTTPHeaders()

--- a/pants/web/asynchronous.py
+++ b/pants/web/asynchronous.py
@@ -29,6 +29,7 @@ import weakref
 from functools import wraps
 from types import GeneratorType
 
+from pants.compat import basestring
 from pants.http.utils import HTTPHeaders
 
 from pants.web.application import Application, error, Response, RequestContext


### PR DESCRIPTION
Also self-explanatory. In contrast to m original py3 branch, I've decided to localize the definition of basestring. As such, modules needed only add a single import, rather than repeating the try/except block everywhere.

PS - This is _not_ a monkey patch! ;-)
