### PR TITLE
Replaced all occurences of (int,long) with Integral

### DIFF
--- a/pants/_channel.py
+++ b/pants/_channel.py
@@ -31,6 +31,8 @@ import socket
 import sys
 import time
 
+from numbers import Integral
+
 from pants.engine import Engine
 from pants.util.sendfile import sendfile
 
@@ -106,7 +108,7 @@ else:
 def sock_type(sock):
     """
     We can thank Linux for this abomination of a function.
-    
+
     As of Linux 2.6.27, bits 11-32 of the socket type are flags. This
     change was made with a complete lack of consideration for the fact
     that socket types are not flags, but are in fact "symbolic
@@ -114,7 +116,7 @@ def sock_type(sock):
     numbers. It is impossible to distinguish between some types (i.e.
     SOCK_STREAM and SOCK_RAW) using a simple bitwise AND, as one would
     expect from a flag value.
-    
+
     To get around this, we treat the first 9 bits as the "real" type.
     """
     return sock.type & 1023
@@ -691,7 +693,7 @@ class _Channel(object):
                 return address, socket.AF_UNIX, True
             raise InvalidAddressFormatError("AF_UNIX not supported.")
 
-        elif isinstance(address, (int, long)):
+        elif isinstance(address, Integral):
             return ('', address), socket.AF_INET, True
 
         elif not isinstance(address, (tuple, list)) or \

--- a/pants/contrib/telnet.py
+++ b/pants/contrib/telnet.py
@@ -23,6 +23,8 @@
 import re
 import struct
 
+from numbers import Integral
+
 from pants import Stream, Server
 
 try:
@@ -134,7 +136,7 @@ class TelnetConnection(Stream):
                 self._telnet_data = ''
                 self._safely_call(self.on_read, data)
 
-            elif isinstance(delimiter, (int, long)):
+            elif isinstance(delimiter, Integral):
                 if len(self._telnet_data) < delimiter:
                     break
                 data = self._telnet_data[:delimiter]
@@ -179,7 +181,7 @@ class TelnetConnection(Stream):
                     self._telnet_data[:self._netstruct_needed])
                 self._telnet_data = self._telnet_data[self._netstruct_needed:]
 
-                if isinstance(data, (int,long)):
+                if isinstance(data, Integral):
                     self._netstruct_needed = data
                     continue
 

--- a/pants/datagram.py
+++ b/pants/datagram.py
@@ -27,6 +27,8 @@ import re
 import socket
 import struct
 
+from numbers import Integral
+
 from pants._channel import _Channel
 
 
@@ -274,7 +276,7 @@ class Datagram(_Channel):
                     self._safely_call(self.on_read, buf)
                     buf = ""
 
-                elif isinstance(delimiter, (int, long)):
+                elif isinstance(delimiter, Integral):
                     if len(buf) < delimiter:
                         break
                     data = buf[:delimiter]

--- a/pants/http/websocket.py
+++ b/pants/http/websocket.py
@@ -327,6 +327,8 @@ import re
 import struct
 import sys
 
+from numbers import Integral
+
 if sys.platform == "win32":
     from time import clock as time
 else:
@@ -742,7 +744,7 @@ class WebSocket(object):
             self._read_delimiter = value
             self._recv_buffer_size_limit = self._buffer_size
 
-        elif isinstance(value, (int, long)):
+        elif isinstance(value, Integral):
             self._read_delimiter = value
             self._recv_buffer_size_limit = max(self._buffer_size, value)
 
@@ -805,10 +807,10 @@ class WebSocket(object):
 
     @buffer_size.setter
     def buffer_size(self, value):
-        if not isinstance(value, (long, int)):
+        if not isinstance(value, Integral):
             raise TypeError("buffer_size must be an int or a long")
         self._buffer_size = value
-        if isinstance(self._read_delimiter, (int, long)):
+        if isinstance(self._read_delimiter, Integral):
             self._recv_buffer_size_limit = max(value, self._read_delimiter)
         elif isinstance(self._read_delimiter, Struct):
             self._recv_buffer_size_limit = max(value,
@@ -1410,7 +1412,7 @@ class WebSocket(object):
                 self._rb_type = None
                 self._safely_call(self.on_read, data)
 
-            elif isinstance(delimiter, (int, long)):
+            elif isinstance(delimiter, Integral):
                 size = len(self._read_buffer)
                 if size < delimiter:
                     break
@@ -1497,7 +1499,7 @@ class WebSocket(object):
                     self._read_buffer = self._read_buffer[self._netstruct_needed:]
 
                 data = self._netstruct_iter.send(data)
-                if isinstance(data, (int, long)):
+                if isinstance(data, Integral):
                     self._netstruct_needed = data
                     continue
 

--- a/pants/stream.py
+++ b/pants/stream.py
@@ -103,7 +103,7 @@ code. Pants handles these errors by passing the resulting exception
 object to one of a number of error handler methods. They are:
 :meth:`~pants.stream.Stream.on_connect_error`,
 :meth:`~pants.stream.Stream.on_overflow_error` and
-:meth:`~pants.stream.Stream.on_error`. Additionally, 
+:meth:`~pants.stream.Stream.on_error`. Additionally,
 :meth:`~pants.stream.Stream.on_ssl_handshake_error` and
 :meth:`~pants.stream.Stream.on_ssl_error` exist to handle SSL-specific
 errors.
@@ -141,6 +141,8 @@ import re
 import socket
 import ssl
 import struct
+
+from numbers import Integral
 
 from pants._channel import _Channel, HAS_IPV6, sock_type
 from pants.engine import Engine
@@ -389,7 +391,7 @@ class Stream(_Channel):
             self._read_delimiter = value
             self._recv_buffer_size_limit = self._buffer_size
 
-        elif isinstance(value, (int, long)):
+        elif isinstance(value, Integral):
             self._read_delimiter = value
             self._recv_buffer_size_limit = max(self._buffer_size, value)
 
@@ -446,10 +448,10 @@ class Stream(_Channel):
 
     @buffer_size.setter
     def buffer_size(self, value):
-        if not isinstance(value, (long, int)):
+        if not isinstance(value, Integral):
             raise TypeError("buffer_size must be an int or a long")
         self._buffer_size = value
-        if isinstance(self._read_delimiter, (int, long)):
+        if isinstance(self._read_delimiter, Integral):
             self._recv_buffer_size_limit = max(value, self._read_delimiter)
         elif isinstance(self._read_delimiter, Struct):
             self._recv_buffer_size_limit = max(value,
@@ -934,7 +936,7 @@ class Stream(_Channel):
                 self._recv_buffer = ""
                 self._safely_call(self.on_read, data)
 
-            elif isinstance(delimiter, (int, long)):
+            elif isinstance(delimiter, Integral):
                 if len(self._recv_buffer) < delimiter:
                     break
                 data = self._recv_buffer[:delimiter]
@@ -980,7 +982,7 @@ class Stream(_Channel):
                     self._recv_buffer[:self._netstruct_needed])
                 self._recv_buffer = self._recv_buffer[self._netstruct_needed:]
 
-                if isinstance(data, (int,long)):
+                if isinstance(data, Integral):
                     self._netstruct_needed = data
                     continue
 

--- a/pants/web/application.py
+++ b/pants/web/application.py
@@ -433,6 +433,7 @@ import traceback
 import urllib
 
 from datetime import datetime
+from numbers import Integral
 
 from pants.http.server import HTTPServer
 from pants.http.utils import HTTP, HTTPHeaders
@@ -1515,7 +1516,7 @@ class Application(Module):
             else:
                 body, status = result
                 headers = HTTPHeaders()
-                
+
         else:
             body = result
             headers = HTTPHeaders()
@@ -1797,7 +1798,7 @@ def error(message=None, status=None, headers=None, request=None, debug=None):
         request = Application.current_app.request
 
     if status is None:
-        if isinstance(message, (int, long)):
+        if isinstance(message, Integral):
             status, message = message, None
         else:
             status = 404


### PR DESCRIPTION
Since python 3 doesn't have a `long` type, I replaced the int/long type checks with one for an Integral, which effectively does the same thing. I should note that for python versions greater than 2.4, integer is largely unconstrained, such that it might be enough to just test for `int`. For instance, on my machine:

``` python
>>> import sys
>>> sys.maxit
9223372036854775807
```

In other words, 2**63 - 1 on a 64bit machine. 2**32 - 1 on a 32bit machine. If there isn't a chance that such high numbers will ever be reached, I can safely change this pull request such that all checks for `(int, long)` check for `int` instead.
