### PR TITLE
Added fixes for WebSocket issues, and extended FileServer

### DIFF
--- a/pants/_channel.py
+++ b/pants/_channel.py
@@ -473,7 +473,7 @@ class _Channel(object):
         except socket.error as err:
             if err.args[0] in (errno.EAGAIN, errno.EWOULDBLOCK):
                 return ''
-            elif err.args[0] == errno.ECONNRESET:
+            elif err.args[0] in (errno.ECONNRESET, errno.ECONNABORTED):
                 return None
             else:
                 raise

--- a/pants/http/websocket.py
+++ b/pants/http/websocket.py
@@ -1287,6 +1287,9 @@ class WebSocket(object):
                 mask = [ord(x) for x in self._recv_buffer[headlen:headlen+4]]
                 headlen += 4
 
+            if type(length) is tuple and len(length) == 1:
+                length = length[0]
+
             total_size = headlen + length
             if len(self._recv_buffer) < total_size:
                 if len(self._recv_buffer) > self._recv_buffer_size_limit:

--- a/pants/web/fileserver.py
+++ b/pants/web/fileserver.py
@@ -130,13 +130,14 @@ class FileServer(object):
         FileServer("/tmp/path").attach(app, "/files/")
     """
     def __init__(self, path, blacklist=(re.compile('.*\.py[co]?$'), ),
-            defaults=('index.html', 'index.htm')):
+            defaults=('index.html', 'index.htm'), headers={}):
         # Make sure our path is unicode.
         if not isinstance(path, unicode):
             path = decode(path)
 
         self.path = os.path.normpath(os.path.realpath(path))
         self.defaults = defaults
+        self.headers = headers
 
         # Build the blacklist.
         self.blacklist = []
@@ -241,7 +242,7 @@ class FileServer(object):
 
         # Let's send the file.
         request.auto_finish = False
-        request.send_file(full_path)
+        request.send_file(full_path, headers=self.headers.copy())
 
 
     def list_directory(self, request, path):


### PR DESCRIPTION
I have seen error 53 (ECONNABORTED) pop up a few times when sending data over WebSockets. My investigation yields that the error is actually harmless, but still annoying when littering the log, so I've extended the error handling code to cover this gracefully.

Also, on at least one occasion **length** was an unpacked tuple with 1 item. Unpacking results in correct behavior, i.e. no truncation of data.

The third change is with regards to the default fallback headers in **send_file**, which always take effect when serving from the FileServer because there was no actual propagation of headers defined elsewhere. More specifically, the default 'max-age=604800' turned out to be an issue in my application, so instead of changing the default I have added a headers= kwarg to **FileServer()**.
